### PR TITLE
Set cookie with access token after auth callback

### DIFF
--- a/functions/trakt-auth-callback.js
+++ b/functions/trakt-auth-callback.js
@@ -17,9 +17,21 @@ exports.handler = async (event, context) => {
           "Content-Type": "application/json",
         } 
       })
+
+    const location = '/'
+    const accessToken = 
+      `trakt_access_token=${response.data.access_token};` +
+      `Max-Age=${response.data.expires_in};` +
+      `Secure;` +
+      `HttpOnly;` +
+      `SameSite=Strict;`
+
     return {
-      statusCode: 200,
-      body: JSON.stringify({ msg: response.data })
+      statusCode: 302,
+      headers: {
+        Location: location,
+        "Set-Cookie": accessToken
+      }
     }
 
   } catch (err) {


### PR DESCRIPTION
This change sets a cookie with key `trakt_access_token` after we finish the auth flow. Not too sure if this is correct but it seems to work. I've put what I think is the most strict security permissions on this, so we may have to tweak them if it prevents us from using the cookie properly. My basic reading makes me feel that this is not the most secure way of dealing with access tokens but it's the best I can come up with right now. Will be good to encrypt the token that we store in the cookie, then it seems pretty secure to me.

The `trakt-auth-callback` also redirects us back to the home page `'/'`. I've had a quick play around with passing a redirect url through if we want it to be customisable, but not sure about it just yet.

Does this seem usable for a 'login to Trakt' button?