### PR TITLE
CORS is fun

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,49 +95,6 @@
 	}
 
 	function login() {
-		// alert('login');
-
-
-		fetch( '/.netlify/functions/trakt-auth', {
-			method: 'GET'
-			,headers: {
-				// 'Content-Type': 'application/json',
-				// 'Access-Control-Allow-Headers': 'Access-Control-Allow-Origin,Origin',
-				'Access-Control-Allow-Origin': 'http://localhost:8888'
-
-				// "Origin": "http://localhost:8888",
-				// "Access-Control-Allow-Origin": "*"
-
-
-			// 'Access-Control-Allow-Origin': 'https://api.trakt.tv'
-			}
-			// ,mode: 'cors'
-		} )
-			.then( ( response ) => {
-
-
-console.log(response);
-
-				if ( response.ok ) {
-// https://developer.mozilla.org/en-US/docs/Web/API/Body/json
-					return response.json();
-				} else {
-					throw new Error( `Something went wrong: ${response.statusText}` );
-				}
-			} )
-			.then( ( data ) => {
-				this.displayMovies = true;
-				this.records = data.records;
-			} )
-			.catch( ( error ) => console.log( error ) );
-
-
-
-
-
-		// alert('login 2');
-
-
-
+		window.location.href = '/.netlify/functions/trakt-auth';
 	}
 </script>


### PR DESCRIPTION
I still don't really understand CORS I guess, but this worked.

I thought the CORS idea was that calls made via client side Javascript have to be made from a domain that is allowed by the server headers. I'm guessing Trakt doesn't allow all domains for their authorisation endpoint, which makes sense I suppose? What I really don't understand is that I thought the Netlify functions are server side code so they shouldn't help to the same CORS restrictions. 

My solution of just going directly to our function URL works, and I think that is actually what we want to do in this simple case.